### PR TITLE
Fix Next.js app directory setup and resolve build type errors

### DIFF
--- a/app/api/completion/route.ts
+++ b/app/api/completion/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from "next/server"
+import { preprocessUserMessage } from "@/message-processor"
+import { formatToPlainText } from "@/fallback-processor"
+import { getMemoryManager } from "@/memory-manager"
+
+export const maxDuration = 30
+
+export async function POST(req: Request) {
+  try {
+    const { messages, model, temperature, top_p, max_tokens, stop } = await req.json()
+    const TOGETHER_API_KEY = process.env.TOGETHER_API_KEY
+
+    if (!TOGETHER_API_KEY) {
+      return NextResponse.json({ error: "API key is not configured in environment variables." }, { status: 500 })
+    }
+
+    const lastUserMessage = messages.filter((m: { role: string }) => m.role === "user").pop()
+    if (lastUserMessage) {
+      lastUserMessage.content = await preprocessUserMessage(lastUserMessage.content)
+    }
+
+    const memoryManager = getMemoryManager()
+    if (lastUserMessage) {
+      const relatedMemories = memoryManager.getRelatedMemories(lastUserMessage.content, 3)
+      if (relatedMemories.length > 0) {
+        const memoryContext = relatedMemories.map((memory: { content: string }) => ({
+          role: "system",
+          content: `Relevant context: ${memory.content}`,
+        }))
+        const lastSystemIndex = messages.findIndex((m: { role: string }) => m.role === "system")
+        if (lastSystemIndex >= 0) {
+          messages.splice(lastSystemIndex + 1, 0, ...memoryContext)
+        } else {
+          messages.unshift(...memoryContext)
+        }
+      }
+    }
+
+    const response = await fetch("https://api.together.xyz/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${TOGETHER_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages,
+        temperature: temperature || 0.7,
+        top_p: top_p || 0.9,
+        max_tokens: max_tokens || 1024,
+        stop,
+      }),
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(`Together.ai API error: ${response.status} ${response.statusText} - ${errorText}`)
+    }
+
+    const data = await response.json()
+    if (!data.choices?.[0]?.message) {
+      throw new Error("Invalid response format from Together.ai API")
+    }
+
+    const completionText = data.choices[0].message.content
+    const formattedResponse = formatToPlainText(completionText)
+
+    if (lastUserMessage) {
+      memoryManager.addEntry({
+        id: `user-${Date.now()}`,
+        role: "user",
+        content: lastUserMessage.content,
+        timestamp: new Date(),
+        metadata: { importance: 0.5 },
+      })
+      memoryManager.addEntry({
+        id: `assistant-${Date.now()}`,
+        role: "assistant",
+        content: formattedResponse,
+        timestamp: new Date(),
+        metadata: { importance: 0.5, model },
+      })
+    }
+
+    return NextResponse.json({ completion: formattedResponse })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error"
+    return NextResponse.json({ error: `Failed to process your request: ${message}` }, { status: 500 })
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react"
+import "../globals.css"
+
+export const metadata = {
+  title: "Sentient AI",
+  description: "Sentient AI chatbot",
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function HomePage() {
+  return (
+    <main style={{ padding: "2rem", fontFamily: "sans-serif" }}>
+      <h1>Sentient AI</h1>
+      <p>App routing has been restored. You can now run and build this Next.js project.</p>
+    </main>
+  )
+}

--- a/fallback-processor.ts
+++ b/fallback-processor.ts
@@ -87,7 +87,7 @@ function generateLocalResponse(
   intent: string,
 ): string {
   // Basic knowledge base for common AI topics
-  const knowledgeBase = {
+  const knowledgeBase: Record<string, string> = {
     "artificial intelligence":
       "Artificial intelligence (AI) refers to systems or machines that mimic human intelligence to perform tasks and can iteratively improve themselves based on the information they collect.",
     "machine learning":

--- a/message-processor.ts
+++ b/message-processor.ts
@@ -349,7 +349,7 @@ function extractKeyTopics(text: string): string[] {
     "transfer learning",
   ]
 
-  const topics = []
+  const topics: string[] = []
   const lowerText = text.toLowerCase()
 
   // First pass: direct matches

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    serverActions: true,
-  },
   async redirects() {
     return [
       {
@@ -16,4 +13,3 @@ const nextConfig = {
 }
 
 export default nextConfig
-

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,15 +13,21 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ],
+    "plugins": [{ "name": "next" }],
     "paths": {
       "@/*": ["./*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "message-processor.ts",
+    "fallback-processor.ts",
+    "memory-manager.ts",
+    "clustering.ts",
+    "text-analysis.ts",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
### Motivation
- Next.js could not detect an `app` or `pages` directory and TypeScript strict checks were causing the production build to fail, so the project needed an app router layout and type fixes to restore buildability and local dev.
- The API completion endpoint was not exposed via the App Router, so requests to `/api/completion` would fail in the app routing setup.

### Description
- Added a minimal App Router with `app/layout.tsx` and `app/page.tsx` so Next can detect application routes and render a homepage. 
- Added `app/api/completion/route.ts` to expose the completion endpoint using the existing `preprocessUserMessage`, `formatToPlainText`, and `getMemoryManager` logic. 
- Removed the invalid `experimental.serverActions` option from `next.config.mjs` to eliminate Next.js config warnings. 
- Narrowed `tsconfig.json` `include` entries to the active `app/` files and backend modules, and fixed TypeScript errors by adding explicit types: `knowledgeBase: Record<string,string>` in `fallback-processor.ts` and `topics: string[]` in `message-processor.ts`.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Started development server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and verified the homepage rendered. 
- Captured a Playwright screenshot of the homepage to validate the app route rendering (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b810ae7c04832bacbeeb1cc249bff2)